### PR TITLE
BUG: Set PointDimension to 3

### DIFF
--- a/src/itkSTLMeshIO.cxx
+++ b/src/itkSTLMeshIO.cxx
@@ -39,6 +39,8 @@ STLMeshIO
   // STL uses UINT32 to store the number of points,
   // hence the point Ids are of the same UINT32 type.
   this->SetCellComponentType(UINT);
+
+  this->SetPointDimension(3);
 }
 
 bool

--- a/test/itkSTLMeshIOTest.cxx
+++ b/test/itkSTLMeshIOTest.cxx
@@ -64,7 +64,6 @@ int itkSTLMeshIOTest(int argc, char * argv[])
 
   mesh->Print( std::cout );
 
-  
 
   writer->SetInput( reader->GetOutput() );
 


### PR DESCRIPTION
STL meshes are always 3D. The default is 0.