### PR TITLE
ENH: Make module name consistent with conventions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
-project(IOSTL)
-set(IOSTL_LIBRARIES IOSTL)
+project(IOMeshSTL)
+set(IOMeshSTL_LIBRARIES IOMeshSTL)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)

--- a/include/itkSTLMeshIO.h
+++ b/include/itkSTLMeshIO.h
@@ -18,7 +18,7 @@
 #ifndef itkSTLMeshIO_h
 #define itkSTLMeshIO_h
 
-#include "IOSTLExport.h"
+#include "IOMeshSTLExport.h"
 
 #include "itkMeshIOBase.h"
 
@@ -33,9 +33,9 @@ namespace itk
  * \author Luis Ibanez, Kitware Inc.
  *
  * \ingroup IOFilters
- * \ingroup IOSTL
+ * \ingroup IOMeshSTL
  */
-class IOSTL_EXPORT STLMeshIO : public MeshIOBase
+class IOMeshSTL_EXPORT STLMeshIO : public MeshIOBase
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(STLMeshIO);

--- a/include/itkSTLMeshIOFactory.h
+++ b/include/itkSTLMeshIOFactory.h
@@ -18,7 +18,7 @@
 #ifndef itkSTLMeshIOFactory_h
 #define itkSTLMeshIOFactory_h
 
-#include "IOSTLExport.h"
+#include "IOMeshSTLExport.h"
 
 #include "itkObjectFactoryBase.h"
 #include "itkMeshIOBase.h"
@@ -28,9 +28,9 @@ namespace itk
 /** \class STLMeshIOFactory
   * \brief Create instances of STLMeshIO objects using an object factory.
   *
-  * \ingroup IOSTL
+  * \ingroup IOMeshSTL
   */
-class IOSTL_EXPORT STLMeshIOFactory:public ObjectFactoryBase
+class IOMeshSTL_EXPORT STLMeshIOFactory:public ObjectFactoryBase
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(STLMeshIOFactory);

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -3,13 +3,13 @@
 get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 
-# itk_module() defines the module dependencies in IOSTL
-# The testing module in IOSTL depends on ITKTestKernel
+# itk_module() defines the module dependencies in IOMeshSTL
+# The testing module in IOMeshSTL depends on ITKTestKernel
 # By convention those modules outside of ITK are not prefixed with
 # ITK.
 
 # define the dependencies of the include module and the tests
-itk_module(IOSTL
+itk_module(IOMeshSTL
   ENABLE_SHARED
   DEPENDS
     ITKCommon

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,9 @@
-set(IOSTL_SRC
+set(IOMeshSTL_SRC
   itkSTLMeshIO.cxx
   itkSTLMeshIOFactory.cxx
 )
 
-add_library(IOSTL ${ITK_LIBRARY_BUILD_TYPE} ${IOSTL_SRC})
-target_link_libraries(IOSTL ${ITKCommon_LIBRARIES} ${ITKIOMesh_LIBRARIES})
+add_library(IOMeshSTL ${ITK_LIBRARY_BUILD_TYPE} ${IOMeshSTL_SRC})
+target_link_libraries(IOMeshSTL ${ITKCommon_LIBRARIES} ${ITKIOMesh_LIBRARIES})
 
-itk_module_target(IOSTL)
+itk_module_target(IOMeshSTL)

--- a/src/itkSTLMeshIOFactory.cxx
+++ b/src/itkSTLMeshIOFactory.cxx
@@ -16,7 +16,7 @@
  *
  *=========================================================================*/
 
-#include "IOSTLExport.h"
+#include "IOMeshSTLExport.h"
 #include "itkSTLMeshIO.h"
 #include "itkSTLMeshIOFactory.h"
 #include "itkVersion.h"
@@ -60,7 +60,7 @@ STLMeshIOFactory
 // DO NOT CALL DIRECTLY.
 static bool STLMeshIOFactoryHasBeenRegistered;
 
-void IOSTL_EXPORT STLMeshIOFactoryRegister__Private()
+void IOMeshSTL_EXPORT STLMeshIOFactoryRegister__Private()
 {
   if( ! STLMeshIOFactoryHasBeenRegistered )
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,62 +1,62 @@
 itk_module_test()
 
-set(IOSTLTests
+set(IOMeshSTLTests
   itkSTLMeshIOTest.cxx
 )
 
-CreateTestDriver(IOSTL "${IOSTL-Test_LIBRARIES}" "${IOSTLTests}" )
+CreateTestDriver(IOMeshSTL "${IOMeshSTL-Test_LIBRARIES}" "${IOMeshSTLTests}" )
 
 itk_add_test(NAME itkSTLMeshIOTest00
-      COMMAND IOSTLTestDriver itkSTLMeshIOTest
+      COMMAND IOMeshSTLTestDriver itkSTLMeshIOTest
       DATA{Baseline/sphere.vtk}
       ${ITK_TEST_OUTPUT_DIR}/sphere00.stl
       0  # write in ASCII
 )
 
 itk_add_test(NAME itkSTLMeshIOTest01
-      COMMAND IOSTLTestDriver itkSTLMeshIOTest
+      COMMAND IOMeshSTLTestDriver itkSTLMeshIOTest
       DATA{Baseline/sphere.vtk}
       ${ITK_TEST_OUTPUT_DIR}/sphere01.stl
       1  # write in BINARY
 )
 
 itk_add_test(NAME itkSTLMeshIOTest02
-      COMMAND IOSTLTestDriver itkSTLMeshIOTest
+      COMMAND IOMeshSTLTestDriver itkSTLMeshIOTest
       DATA{Baseline/sphere.stl}
       ${ITK_TEST_OUTPUT_DIR}/sphere02.stl
       0  # write in ASCII
 )
 
 itk_add_test(NAME itkSTLMeshIOTest03
-      COMMAND IOSTLTestDriver itkSTLMeshIOTest
+      COMMAND IOMeshSTLTestDriver itkSTLMeshIOTest
       DATA{Baseline/sphere.stl}
       ${ITK_TEST_OUTPUT_DIR}/sphere03.stl
       1  # write in BINARY
 )
 
 itk_add_test(NAME itkSTLMeshIOTest04
-      COMMAND IOSTLTestDriver itkSTLMeshIOTest
+      COMMAND IOMeshSTLTestDriver itkSTLMeshIOTest
       DATA{Baseline/tetrahedron.vtk}
       ${ITK_TEST_OUTPUT_DIR}/tetrahedron01.stl
       0  # write in ASCII
 )
 
 itk_add_test(NAME itkSTLMeshIOTest05
-      COMMAND IOSTLTestDriver itkSTLMeshIOTest
+      COMMAND IOMeshSTLTestDriver itkSTLMeshIOTest
       DATA{Baseline/tetrahedron.vtk}
       ${ITK_TEST_OUTPUT_DIR}/tetrahedron02.stl
       1  # write in BINARY
 )
 
 itk_add_test(NAME itkSTLMeshIOTest06
-      COMMAND IOSTLTestDriver itkSTLMeshIOTest
+      COMMAND IOMeshSTLTestDriver itkSTLMeshIOTest
       DATA{Baseline/tetrahedron.stl}
       ${ITK_TEST_OUTPUT_DIR}/tetrahedron03.stl
       0  # write in ASCII
 )
 
 itk_add_test(NAME itkSTLMeshIOTest07
-      COMMAND IOSTLTestDriver itkSTLMeshIOTest
+      COMMAND IOMeshSTLTestDriver itkSTLMeshIOTest
       DATA{Baseline/tetrahedron.stl}
       ${ITK_TEST_OUTPUT_DIR}/tetrahedron04.stl
       1  # write in BINARY

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,3 +1,3 @@
-itk_wrap_module(IOSTL)
+itk_wrap_module(IOMeshSTL)
 itk_auto_load_submodules()
 itk_end_wrap_module()


### PR DESCRIPTION
Since the repository name is ITKIOMeshSTL and it is an external/remote
module, name the module IOMeshSTL according to our naming convention.